### PR TITLE
package license in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license-file = LICENSE


### PR DESCRIPTION
Include the `LICENSE` file in both `sdist`s and wheels, so users/redistributors can more easily follow the terms of your license.